### PR TITLE
fix: WIT exports

### DIFF
--- a/filer/wit/world.wit
+++ b/filer/wit/world.wit
@@ -1,9 +1,15 @@
 package wasmcloud:filer;
 
+interface handler {
+   handle-message: func(data: list<u8>) -> result<_, string>;
+}
+
 world filer {
    import wasi:logging/logging@0.1.0-draft;
    import wasmcloud:messaging/consumer@0.2.0;
    import wasmcloud:example/fs-storage;
+
+   export handler;
 
    export wasi:http/incoming-handler@0.2.2;
 }


### PR DESCRIPTION
This commit reuses the `wasmcloud_component` machinery to export `wasi:http/incoming-handler`, along with the rest of the interfaces used by the `filer` component.